### PR TITLE
Fix for Payload V2: address case when user is null

### DIFF
--- a/src/authorHook.ts
+++ b/src/authorHook.ts
@@ -12,7 +12,8 @@ export const authorHook = (
     if (
       args.operation === 'update' &&
       args.data !== undefined &&
-      args.req.user !== undefined
+      args.req.user !== undefined &&
+      args.req.user !== null
     ) {
       args.data[updatedByFieldName] = {
         relationTo: userSlug,


### PR DESCRIPTION
Without addressing this, archiving customer recipes fails